### PR TITLE
Update argonaut version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,8 +14,8 @@
         "output"
     ],
     "dependencies": {
-        "purescript-affjax": "^v10.0.0",
-        "purescript-argonaut": "^v6.0.0",
+        "purescript-affjax": "^v10.1.0",
+        "purescript-argonaut": "^v7.0.0",
         "purescript-debug": "^v4.0.0",
         "purescript-numbers": "^v7.0.0",
         "purescript-polyform": "^v0.8.2",

--- a/test/Duals/Validators/Json.purs
+++ b/test/Duals/Validators/Json.purs
@@ -2,8 +2,8 @@ module Test.Duals.Validators.Json where
 
 import Prelude hiding (unit)
 
+import Data.Argonaut (JsonDecodeError(..), fromBoolean, fromNumber, fromObject, fromString, jsonNull, stringify, toObject)
 import Data.Argonaut (fromBoolean, fromNumber) as Argonaut
-import Data.Argonaut (fromBoolean, fromNumber, fromObject, fromString, jsonNull, stringify, toObject)
 import Data.Argonaut (fromString, stringify) as Argounaut
 import Data.Argonaut.Core (Json)
 import Data.Generic.Rep (class Generic)
@@ -166,12 +166,12 @@ suite =
             [ "tag" /\ fromString "S", "value" /\ fromNumber 8.0 ]
           _json = SProxy ∷ SProxy "json"
           errs =
-            [ inj _json { msg: "number is not a string", path: List.Nil }
-            , inj _json { msg: "Incorrect tag: S", path: List.Nil }
-            , inj _json { msg: "Incorrect tag: S", path: List.Nil }
-            , inj _json { msg: "Incorrect tag: S", path: List.Nil }
-            , inj _json { msg: "Incorrect tag: S", path: List.Nil }
-            , inj _json { msg: "Incorrect tag: S", path: List.Nil }
+            [ inj _json { msg: TypeMismatch "String", path: List.Nil }
+            , inj _json { msg: Named "Incorrect tag" (UnexpectedValue (fromString "S")), path: List.Nil }
+            , inj _json { msg: Named "Incorrect tag" (UnexpectedValue (fromString "S")), path: List.Nil }
+            , inj _json { msg: Named "Incorrect tag" (UnexpectedValue (fromString "S")), path: List.Nil }
+            , inj _json { msg: Named "Incorrect tag" (UnexpectedValue (fromString "S")), path: List.Nil }
+            , inj _json { msg: Named "Incorrect tag" (UnexpectedValue (fromString "S")), path: List.Nil }
             ]
         parsedS' ← runValidator (parser sumD) s'
 


### PR DESCRIPTION
The most recent [major release of the Argonaut library](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0) introduces typed errors. This PR updates this library to be compatible.

Unfortunately it looks like some 0.14-related changes have already been merged, which will make this library incompatible with the upcoming package set if this code is merged directly into master. I'm not sure how you'd like to handle that. Ideally, the 0.14 changes could sit in an unreleased branch and a new release could be made with these Argonaut-related changes for the next package set. Then, the 0.14-related changes can be merged in later.

I've verified that the tests are passing with these changes.

Sorry for the hassle! Thanks!